### PR TITLE
issue fixed for visualizer

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
       </header>
 
       <section class="main-controls">
-        <canvas class="visualizer"></canvas>
+        <canvas class="visualizer" height="60px"></canvas>
         <div id="buttons">
           <button class="record">Record</button>
           <button class="stop">Stop</button>

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -12,6 +12,7 @@ var record = document.querySelector('.record');
 var stop = document.querySelector('.stop');
 var soundClips = document.querySelector('.sound-clips');
 var canvas = document.querySelector('.visualizer');
+var mainSection = document.querySelector('.main-controls');
 
 // disable stop button while not recording
 
@@ -130,13 +131,12 @@ function visualize(stream) {
 
   source.connect(analyser);
   //analyser.connect(audioCtx.destination);
-  
-  WIDTH = canvas.width
-  HEIGHT = canvas.height;
 
   draw()
 
   function draw() {
+    WIDTH = canvas.width
+    HEIGHT = canvas.height;
 
     requestAnimationFrame(draw);
 
@@ -174,3 +174,7 @@ function visualize(stream) {
   }
 }
 
+window.onresize = function() {
+  canvas.width = mainSection.offsetWidth;
+}
+window.onresize();

--- a/styles/app.css
+++ b/styles/app.css
@@ -31,8 +31,6 @@ h1, h2 {
 }
 
 canvas {
-  width: 100%;
-  height: 60px;
   display: block;
   margin-bottom: 0.5rem;
 }


### PR DESCRIPTION
Using CSS to control the size of canvas won't change the real rendering size of canvas. So the image is scaled to fit its layout size. If the CSS sizing doesn't respect the ratio of the initial canvas, it will appear distorted.
